### PR TITLE
Fix markdown links job

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.13
+    - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
       with:
         use-quiet-mode: 'yes'


### PR DESCRIPTION
Looks like "v1" becomes "1.1.13" not "v1.1.13" - no way to test apart from merging to main :(