### PR TITLE
Ignore Obsidian files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.obsidian
+.vs
 *.code-workspace
 !project.code-workspace
-.vs/*

--- a/project.code-workspace
+++ b/project.code-workspace
@@ -146,7 +146,8 @@
       "titleBar.activeBackground": "#00b3e6",
       "titleBar.activeForeground": "#15202b",
       "titleBar.inactiveBackground": "#00b3e699",
-      "titleBar.inactiveForeground": "#15202b99"
+      "titleBar.inactiveForeground": "#15202b99",
+      "commandCenter.border": "#15202b99"
     },
     "peacock.color": "#00b3e6"
   }


### PR DESCRIPTION
This PR is to ignore configuration Obsidian files.

[Obsidian](https://obsidian.md/) is a knowledge base tool that operates on Markdown. An example below is a view of a basic map of file relations

![Screenshot 2022-08-17 at 08 31 05](https://user-images.githubusercontent.com/499338/185061091-192841e4-818e-49b7-8d0f-fe5865c47459.png)

