### PR TITLE
Improved commit signing guide for macOS

### DIFF
--- a/practices/guides/commit-signing.md
+++ b/practices/guides/commit-signing.md
@@ -41,7 +41,9 @@ git config --global user.name ${my_username}
 git config --global commit.gpgsign true
 echo export GPG_TTY=\$\(tty\) >> ~/.zshrc
 source ~/.zshrc
-echo "pinentry-program /opt/homebrew/bin/pinentry-mac" >> ~/.gnupg/gpg-agent.conf
+PINENTRY_BIN=$(whereis -q pinentry-mac)
+sed -i '' '/pinentry-program/d' ~/.gnupg/gpg-agent.conf
+echo "pinentry-program ${PINENTRY_BIN}" >> ~/.gnupg/gpg-agent.conf
 gpgconf --kill gpg-agent
 ```
 


### PR DESCRIPTION
Having walked through the "Commit Signing on macOS" process with a colleague recently I have ironed out a significant gotcha.

Brew on macOS either seems to either use _/usr/local/bin_ or _/opt/homebrew/bin_ for its binaries, depending on the age of the install. GPG signing fails silently if the passphrase pinentry helper binary cannot be found which is very confusing to troubleshoot. The changes in this PR take that challenge into account when setting up _gpg-agent.conf_.