### PR TITLE
Another small enhancement to git commit signing guide

### DIFF
--- a/practices/guides/commit-signing.md
+++ b/practices/guides/commit-signing.md
@@ -39,10 +39,11 @@ gpg --armor --export ${my_email_address} | pbcopy
 git config --global user.email ${my_email_address} # same one used during key generation
 git config --global user.name ${my_username}
 git config --global commit.gpgsign true
+sed -i '' '/^export GPG_TTY/d' ~/.zshrc
 echo export GPG_TTY=\$\(tty\) >> ~/.zshrc
 source ~/.zshrc
 PINENTRY_BIN=$(whereis -q pinentry-mac)
-sed -i '' '/pinentry-program/d' ~/.gnupg/gpg-agent.conf
+sed -i '' '/^pinentry-program/d' ~/.gnupg/gpg-agent.conf
 echo "pinentry-program ${PINENTRY_BIN}" >> ~/.gnupg/gpg-agent.conf
 gpgconf --kill gpg-agent
 ```


### PR DESCRIPTION
## Another small enhancement to the git commit signing guide

Another small bash script enhancement to prevent duplicate changes to _~/.zshrc_ where a system may already have a definition for variable GPG_TTY. It is now idempotent.