### PR TITLE
Add SECURITY.md and notes on PVR

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ If you believe you have found a security issue in this repository, please report
 1. [Report a vulnerability](https://github.com/NHSDigital/software-engineering-quality-framework/security/advisories/new)
 2. Provide details of the issue and steps to reproduce
 
-This creates a private channel for discussion and allows us to coordinate a fix before public disclosure.
+This creates a private channel for discussion and allows us to coordinate a fix before any public disclosure.
 
 ## General Security Enquiries
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security
 
-We take security and the protection of private data extremely seriously. If you believe you have found a vulnerability or other issue which has compromised or could compromise the security of any of our systems and/or private data managed by our systems, please do not hesitate to contact us using the method outlined below.
+We take security and the protection of private data extremely seriously. If you believe you have found a vulnerability or other issue which has compromised or could compromise the security of any of our systems or private data managed by our systems, please do not hesitate to contact us using the method outlined below.
 
 ## Table of Contents
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security
+
+We take security and the protection of private data extremely seriously. If you believe you have found a vulnerability or other issue which has compromised or could compromise the security of any of our systems and/or private data managed by our systems, please do not hesitate to contact us using the method outlined below.
+
+## Table of Contents
+
+- [Security](#security)
+  - [Table of Contents](#table-of-contents)
+  - [Reporting a vulnerability](#reporting-a-vulnerability)
+  - [General Security Enquiries](#general-security-enquiries)
+
+## Reporting a vulnerability
+
+If you believe you have found a security issue in this repository, please report it using GitHub's private vulnerability reporting:
+
+1. [Report a vulnerability](https://github.com/NHSDigital/software-engineering-quality-framework/security/advisories/new)
+2. Provide details of the issue and steps to reproduce
+
+This creates a private channel for discussion and allows us to coordinate a fix before public disclosure.
+
+## General Security Enquiries
+
+If you have general enquiries regarding our cybersecurity, please reach out to us at [cybersecurity@nhs.net](cybersecurity@nhs.net)

--- a/practices/securing-repositories.md
+++ b/practices/securing-repositories.md
@@ -9,6 +9,7 @@
     - [Teams setup](#teams-setup)
   - [Code security](#code-security)
     - [Branch protection](#branch-protection)
+  - [Allowing others to report security problems](#allowing-others-to-report-security-problems)
 
 This guide lays out security best practice for GitHub repositories. This set of practices is a minimum (nothing stops you from doing more), and they should be implemented alongside other relevant ones that contribute to [security](security.md) as a whole. These are discussed in more detail as part of the [Quality checks](../quality-checks.md).
 
@@ -64,3 +65,13 @@ Depending on your use case, you may want to create additional teams (e.g. teams 
 - Require <!-- markdown-link-check-disable -->[signed commits](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-signed-commits)<!-- markdown-link-check-enable -->, and, accordingly, check that commits are verified before merging. Git treats authentication and identity separately - any authenticated user can impersonate another developer when committing code. This means that even if a junior account is compromised it could have significant consequences, for example impersonating the lead developer in the hope of an easy merge. Only by requiring signing can identity truly be verified. [Setup Guides](guides/commit-signing.md) for macOS, Windows, GitHub Actions, and AWS CodePipeline.
 - Invalidate existing reviews when new commits are pushed (`Dismiss stale pull request approvals when new commits are pushed` option).
 - Require adequate automated status checks prior to merging. This should always include checking that branches are up to date.
+
+## Allowing others to report security problems
+
+- Provide a SECURITY.md file describing how other people should report any security issues they discover in your repository.
+- Enable Security advisories in your repository as the preferred means of other people reporting security issues.
+- If your repository is public, also enable [Private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/privately-reporting-a-security-vulnerability) so that external users can report issues privately.
+  - Note: the "Enable vulnerability reporting" button in the "Security and Quality" tab doesn't actually enable this setting: it just takes you to the "Settings" tab where the real "Enable" button is.
+- Ensure that you monitor Security advisories and act on them promptly.
+
+For an example, please see this repository's [SECURITY.md](../SECURITY.md).


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` file to the repository and documents best practices for allowing others to report security problems.

## Changes

### Added `SECURITY.md`

- Provides guidance on how to report security vulnerabilities
- Uses GitHub's Private Vulnerability Reporting (PVR) as the primary reporting method
- Includes a direct link to the vulnerability reporting form for ease of use
- Retains contact details for general security enquiries

### Updated `practices/securing-repositories.md`

Added a new section "Allowing others to report security problems" covering:

- Adding a `SECURITY.md` file to repositories
- Enabling Security advisories
- Enabling Private vulnerability reporting for public repositories
- Monitoring and acting on security advisories

Also links to this repository's `SECURITY.md` as a working example.

## Why

Public repositories should make it easy for security researchers and users to report vulnerabilities privately. GitHub's Private Vulnerability Reporting provides a low-friction, secure channel that doesn't require external reporters to manage email or tokens — they just need a GitHub account.

## Checklist

- [x] `SECURITY.md` added to repository root
- [x] Private vulnerability reporting enabled in repository settings
- [x] Documentation updated with guidance for other teams